### PR TITLE
Bugfix related to newscan.x and creation of SLP

### DIFF
--- a/include/ms/ms_rle_string.hpp
+++ b/include/ms/ms_rle_string.hpp
@@ -274,7 +274,7 @@ ms_rle_string<ri::sparse_sd_vector, ri::huff_string>::ms_rle_string(std::ifstrea
     {
         size_t length = 0;
         lengths.read((char *)&length, 5);
-        if (run_heads_s[i] <= TERMINATOR) // change 0 to 1
+        if (unsigned(run_heads_s[i]) <= TERMINATOR) // change 0 to 1
             run_heads_s[i] = TERMINATOR;
 
         if(i % B == B - 1)

--- a/include/ms/ms_rle_string.hpp
+++ b/include/ms/ms_rle_string.hpp
@@ -274,15 +274,19 @@ ms_rle_string<ri::sparse_sd_vector, ri::huff_string>::ms_rle_string(std::ifstrea
     {
         size_t length = 0;
         lengths.read((char *)&length, 5);
-        if (unsigned(run_heads_s[i]) <= TERMINATOR) // change 0 to 1
+
+        uint8_t curr_ch = unsigned(run_heads_s[i]);
+        if (curr_ch <= TERMINATOR) { // change 0 to 1
             run_heads_s[i] = TERMINATOR;
+            curr_ch = TERMINATOR;
+        }
 
         if(i % B == B - 1)
             runs_bv_onset.push_back(this->n + length - 1);
 
         assert(length > 0);
-        runs_per_letter_bv_i[run_heads_s[i]] += length;
-        runs_per_letter_bv[run_heads_s[i]].push_back(runs_per_letter_bv_i[run_heads_s[i]] - 1);
+        runs_per_letter_bv_i[curr_ch] += length;
+        runs_per_letter_bv[curr_ch].push_back(runs_per_letter_bv_i[curr_ch] - 1);
 
         this->n += length;
     }

--- a/pipeline/moni.in
+++ b/pipeline/moni.in
@@ -417,6 +417,11 @@ def build(args):
   if args.f and args.threads > 0 and (".fq" in args.reference or ".fastq" in args.reference or ".fnq" in args.reference):
     print("moni does not current support FASTQ format! Exiting...", flush=True)
     return
+
+  # added to avoid using newscan.x until issue is further investigated
+  if args.f and args.threads > 0:
+    print("\nerror: moni's multithreading is not currently available.\n")
+    exit(0)
   
   filename = os.path.basename(args.reference)
   if args.output != ".":


### PR DESCRIPTION
Hi Max,

There are two separate issues that occur when a reference text begins with a trigger string, where `mod p == 0`. Here is a brief description of the issues.

1. When using multiple threads, `moni` will use `newscan.x` to create the `*.parse` and `*.dict` file but `newscan.x` has a issue where it will not report the first trigger string as a phrase and this leads to `pfp_thresholds` creating an incorrect BWT. 
    - **Solution/Workaround:** Not use any multi-threading since `newscanNT.x` does not have that same issue. It appears like `newscan.x` might require some more testing to ensure that there are no differences with the single-threaded version.

2. When the first w-mer is a trigger string, downstream, `compress_dictionary` will write the compressed length of each phrase after stripping the trigger string but that will be 0. This causes an issue later on because when `procdic` combines the grammar of the parse and dictionary, it will try to create a rule for the first phrase but there is no text in the `*.dicz` to create a grammar for so it pushes all the rules off by one. Long story short, it creates an incorrect SLP so matching statistics are incorrect because the random-access to the text in the second pass it not correct.

    - **Solution/Workaround:** Remove that first phrase from `*.dicz` and `*.dicz.len` and decrement all phrase ID in the `*.parse` file to ensure the `*.dicz` and `*.parse` file have the same number of phrases and they correspond to each other.

Here is an example text that causes this issue for testing:

```
>example_reference
AAATATATATAAATATATATATAAGTAAATATAAATATTATATAGATATATAAATATATAAATATATATATAATATATAA
TAAATATATATATAAATAAATATAAATATATATAAATATATATAAATAAATATATATAAATATATATAAATATATAAATA
TATATATATATATATATATAGTACTGCCTGCTGGAGAGTCCATTCTAGATAACCAACAAACCCTCAAACTTAGTTCACTA
TGTTTACTCCCCAAATCTGCTTCCCTTCTCATGTGATGCCAGAAAAGATATTAAACATTCATCCCCTTGCCAAGGCTGGG
```