### PR TITLE
Emit valid SAM format outputs

### DIFF
--- a/include/extender/extender_klib.hpp
+++ b/include/extender/extender_klib.hpp
@@ -342,9 +342,9 @@ public:
 
     std::string to_sam()
     {
-        std::string res = "@HD VN:1.6 SO:unknown\n";
+        std::string res = "@HD\tVN:1.6\tSO:unknown\n";
         res += idx.to_sam();
-        res += "@PG ID:moni PN:moni VN:0.1.0\n";
+        res += "@PG\tID:moni\tPN:moni\tVN:0.1.0\n";
         return res; 
     }
 

--- a/include/extender/extender_ksw2.hpp
+++ b/include/extender/extender_ksw2.hpp
@@ -738,7 +738,7 @@ public:
 
     std::string to_sam()
     {
-        std::string res = "@HD VN:1.6 SO:unknown\n";
+        std::string res = "@HD\tVN:1.6\tSO:unknown\n";
         res += idx.to_sam();
         res += "@PG\tID:moni\tPN:moni\tVN:0.1.0\n";
         return res; 


### PR DESCRIPTION
The current SAM format output does not work properly with tools like `samtools`. Checking it with the `quickcheck` command, I get:

```shell
samtools quickcheck reads.sam
reads.sam was not identified as sequence data.
```

The problems were a few non-TAB-separated rows.